### PR TITLE
chore: replace Cloudinary URLs with direct dnbradio.com image URLs

### DIFF
--- a/components/StationDetails.vue
+++ b/components/StationDetails.vue
@@ -848,44 +848,32 @@ export default {
               // album: this.nowplaying.album,
               artwork: [
                 {
-                  src:
-                    "https://res.cloudinary.com/dgp7z9vkg/image/fetch/c_scale,w_96/v1586048258/" +
-                    this.pageImage,
+                  src: this.pageImage,
                   sizes: "96x96",
                   type: "image/png",
                 },
                 {
-                  src:
-                    "https://res.cloudinary.com/dgp7z9vkg/image/fetch/c_scale,w_128/v1586048258/" +
-                    this.pageImage,
+                  src: this.pageImage,
                   sizes: "128x128",
                   type: "image/png",
                 },
                 {
-                  src:
-                    "https://res.cloudinary.com/dgp7z9vkg/image/fetch/c_scale,w_192/v1586048258/" +
-                    this.pageImage,
+                  src: this.pageImage,
                   sizes: "192x192",
                   type: "image/png",
                 },
                 {
-                  src:
-                    "https://res.cloudinary.com/dgp7z9vkg/image/fetch/c_scale,w_256/v1586048258/" +
-                    this.pageImage,
+                  src: this.pageImage,
                   sizes: "256x256",
                   type: "image/png",
                 },
                 {
-                  src:
-                    "https://res.cloudinary.com/dgp7z9vkg/image/fetch/c_scale,w_348/v1586048258/" +
-                    this.pageImage,
+                  src: this.pageImage,
                   sizes: "384x384",
                   type: "image/png",
                 },
                 {
-                  src:
-                    "https://res.cloudinary.com/dgp7z9vkg/image/fetch/c_scale,w_512/v1586048258/" +
-                    this.pageImage,
+                  src: this.pageImage,
                   sizes: "512x512",
                   type: "image/png",
                 },

--- a/data/stations.js
+++ b/data/stations.js
@@ -9,7 +9,7 @@ export default async function data() {
       title: "dnbradio.com",
       subtitle: "all flavors",
       cover:
-        "https://res.cloudinary.com/dgp7z9vkg/image/fetch/b_auto,c_pad,w_960/https://staging.dnbradio.com/images/logotags.png",
+        "https://dnbradio.com/images/logotags.png",
       website: "https://dnbradio.com/?forceMobile=0",
       facebook: "https://facebook.com/dnbradio",
       twitter: "https://twitter.com/dnbradio",
@@ -44,7 +44,7 @@ export default async function data() {
       title: "plushrecs",
       subtitle: "Lush jungle and drum and bass",
       cover:
-        "https://res.cloudinary.com/dgp7z9vkg/image/fetch/b_auto,c_pad,w_960/https://staging.dnbradio.com/images/plushrecs.png",
+        "https://dnbradio.com/images/plushrecs.png",
       website: "https://plushrecs.com",
       facebook: "https://facebook.com/plushrecs",
       twitter: "https://twitter.com/plushrecs",
@@ -78,7 +78,7 @@ export default async function data() {
       title: "jungletrain",
       subtitle: "A train in constant motion",
       cover:
-        "https://res.cloudinary.com/dgp7z9vkg/image/fetch/b_auto,c_pad,w_960/https://staging.dnbradio.com/images/jungletrain.png",
+        "https://dnbradio.com/images/jungletrain.png",
       website: "https://jungletrain.net",
       facebook: "https://facebook.com/jungletrain",
       twitter: "https://twitter.com/jungletrain",
@@ -112,7 +112,7 @@ export default async function data() {
       title: "section8recs",
       subtitle: "Dark heavy drum and bass",
       cover:
-        "https://res.cloudinary.com/dgp7z9vkg/image/fetch/b_auto,c_pad,w_960/https://staging.dnbradio.com/images/section8recs.png",
+        "https://dnbradio.com/images/section8recs.png",
       website: "https://section8recs.com",
       facebook: "https://facebook.com/section8recs",
       twitter: "https://twitter.com/section8recs",
@@ -146,7 +146,7 @@ export default async function data() {
       title: "dark.st",
       subtitle: "dnbradio's darkstep channel",
       cover:
-        "https://res.cloudinary.com/dgp7z9vkg/image/fetch/b_auto,c_pad,w_960/https://staging.dnbradio.com/images/darkstep.png",
+        "https://dnbradio.com/images/darkstep.png",
       website: "http://section8recs.com",
       facebook: "https://facebook.com/dnbradio",
       twitter: "https://twitter.com/section8recs",

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -66,7 +66,6 @@ export default {
   left: 0;
   width: 100%;
   height: 100%;
-  /* background-image: url('https://res.cloudinary.com/dgp7z9vkg/image/upload/c_scale,w_1436/v1585703166/bg.jpg'); */
   filter: grayscale(100%);
   background-size: cover;
   background-position: top;

--- a/layouts/legacy.vue
+++ b/layouts/legacy.vue
@@ -7,7 +7,7 @@
             <v-card flat style="background:none; width: 220px;">
               <div style="min-height: 440px; padding:10px;">
                 <img
-                  src="https://res.cloudinary.com/dgp7z9vkg/image/upload/c_scale,w_269/v1597369102/logotags_zoom_1400_dnbr_dnbr-cropped.png"
+                  src="https://dnbradio.com/images/logotags.png"
                   width="203"
                   height="212"
                 />

--- a/plugins/createjs.js
+++ b/plugins/createjs.js
@@ -14,7 +14,7 @@ Vue.prototype.$sound = media.audio(
     volume: 1,
     autoplay: true,
     poster:
-      "https://res.cloudinary.com/dgp7z9vkg/image/upload/c_scale,w_869/v1597369102/logotags_zoom_1400_dnbr_dnbr-cropped.png",
+      "https://dnbradio.com/images/logotags.png",
     preload: "auto"
   }
 );


### PR DESCRIPTION
Cloudinary is no longer used as an image proxy. All image/fetch URLs pointing through res.cloudinary.com (which in turn fetched from staging.dnbradio.com) are replaced with direct dnbradio.com/images/* paths. Uploaded Cloudinary assets (logo) are also replaced with the canonical dnbradio.com URL.